### PR TITLE
修复当数组中某个元素相加2次和target相等时导致输出的数据为同一个数组下标

### DIFF
--- a/src/main/java/com/crossoverjie/algorithm/TwoSum.java
+++ b/src/main/java/com/crossoverjie/algorithm/TwoSum.java
@@ -26,7 +26,7 @@ public class TwoSum {
             for (int j = nums.length -1 ;j >=0 ;j--){
                 int b = nums[j] ;
 
-                if ((a+b) == target){
+                if (i != j && (a + b) == target) {
                     result = new int[]{i,j} ;
                 }
             }

--- a/src/main/java/com/crossoverjie/algorithm/TwoSum.java
+++ b/src/main/java/com/crossoverjie/algorithm/TwoSum.java
@@ -19,7 +19,7 @@ public class TwoSum {
      * @return
      */
     public int[] getTwo1(int[] nums,int target){
-        int[] result = new int[2] ;
+        int[] result = null;
 
         for (int i= 0 ;i<nums.length ;i++){
             int a = nums[i] ;


### PR DESCRIPTION
bugfix
description of the PR:**
### 修复当数组中某个元素相加2次和target相等时导致输出的数据为同一个数组下标
 int[] nums = {876,879,155,291,431,14,592} ,target=28时会输出[5,5]