### PR TITLE
双向链表删除节点时，只修改了当前后驱节点，未修改当前节点的前驱节点，修改此BUG

### DIFF
--- a/src/main/java/com/crossoverjie/actual/LRUMap.java
+++ b/src/main/java/com/crossoverjie/actual/LRUMap.java
@@ -88,6 +88,7 @@ public class LRUMap<K, V> {
         if (node.tail != null && node.next != null){
             //它的上一节点指向它的下一节点 也就删除当前节点
             node.tail.next = node.next ;
+            node.next.tail = node.tail;
             nodeCount -- ;
         }
 


### PR DESCRIPTION
```java  
       LRUMap<String,Integer> lru = new LRUMap<>(5);


        lru.put("1",1);
        lru.put("2",1);
        lru.put("3",1);
        lru.put("4",1);
        lru.put("5",1);

        System.out.println(lru.toString());

        lru.get("2");
        lru.get("3");
        lru.get("4");
        lru.get("5");

        lru.put("6",1);
        System.out.println(lru.toString());
```

输出：
1:1-->2:1-->3:1-->4:1-->5:1-->
3:1-->5:1-->2:1-->3:1-->4:1-->5:1-->6:1-->

链表数据出错，原因：双向链表删除节点时，只修改了当前后驱节点，未修改当前节点的前驱节点
