### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka_2.11 to 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.11</artifactId>
-            <version>0.10.0.1</version>
+            <version>1.0.1</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka_2.11 0.10.0.1
- [CVE-2017-12610](https://www.oscs1024.com/hd/CVE-2017-12610)


### What did I do？
Upgrade org.apache.kafka:kafka_2.11 from 0.10.0.1 to 1.0.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS